### PR TITLE
Correlation id with debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Ideal use cases are:
 - interaction with services that simply don't support transactions
 - composing multiple workflows that can share steps (with the
   help of `Kernel.defdelegate/2`)
+- trace workflows execution via a correlation id
 
 You can avoid using this library if:
 
@@ -89,7 +90,7 @@ defmodule StartNewConversation do
                   :broadcast_new_message]
 
   def handle_result(state) do
-    {:ok, state.assigns.conversation}
+    state.assigns.conversation
   end
 
   def handle_error(:create_initial_message, _error, state) do

--- a/lib/recipe.ex
+++ b/lib/recipe.ex
@@ -217,12 +217,6 @@ defmodule Recipe do
   end
 
   @doc """
-  Runs a recipe, identified by a module which implements the `Recipe` behaviour.
-  """
-  @spec run(recipe_module) :: {:ok, term} | {:error, term}
-  def run(recipe_module), do: run(recipe_module, empty_state())
-
-  @doc """
   Runs a recipe, identified by a module which implements the `Recipe`
   behaviour, also allowing to specify the initial state.
   """

--- a/lib/recipe.ex
+++ b/lib/recipe.ex
@@ -208,9 +208,9 @@ defmodule Recipe do
 
   Keys are available for reading under the `assigns` key.
 
-  iex> state = Recipe.empty_state |> Recipe.assign(:user_id, 1)
-  iex> state.assigns.user_id
-  1
+      iex> state = Recipe.empty_state |> Recipe.assign(:user_id, 1)
+      iex> state.assigns.user_id
+      1
   """
   @spec assign(State.t, atom, term) :: State.t
   def assign(state, key, value) do

--- a/lib/recipe.ex
+++ b/lib/recipe.ex
@@ -22,6 +22,7 @@ defmodule Recipe do
   - interaction with services that simply don't support transactions
   - composing multiple workflows that can share steps (with the
     help of `Kernel.defdelegate/2`)
+  - trace workflows execution via a correlation id
 
   You can avoid using this library if:
 
@@ -39,6 +40,7 @@ defmodule Recipe do
   - Each step is a separate function that receives a state
     with the result of all previous steps
   - Each step should be easily testable in isolation
+  - Each workflow run is identified by a correlation id
 
   ### Example
 
@@ -74,7 +76,7 @@ defmodule Recipe do
                         :broadcast_new_message]
 
         def handle_result(state) do
-          {:ok, state.assigns.conversation}
+          state.assigns.conversation
         end
 
         def handle_error(:create_initial_message, _error, state) do
@@ -126,13 +128,13 @@ defmodule Recipe do
       end
   """
 
-  alias Recipe.State
+  alias Recipe.{State, UUID}
   require Logger
 
   @type step :: atom
   @type recipe_module :: atom
   @type error :: term
-  @type debug_opts :: [{:log_steps, boolean}]
+  @type run_opts :: [{:log_steps, boolean} | {:correlation_id, UUID.t}]
 
   @doc """
   Lists all steps included in the recipe, e.g. `[:square, :double]`
@@ -222,9 +224,16 @@ defmodule Recipe do
   Runs a recipe, identified by a module which implements the `Recipe`
   behaviour, allowing to specify the initial state.
 
+  In case of a successful run, it will return a 3-element tuple `{:ok,
+  correlation_id, result}`, where `correlation_id` is a uuid that can be used
+  to connect this workflow with another one and `result` is the return value of
+  the `handle_result/1` callback.
+
   Supports an optional third argument (a keyword list) for extra options:
 
   - `:log_steps`: when true, log (at debug level) each step with the updated state
+  - `:correlation_id`: you can override the automatically generated correlation id
+    by passing it as an option. A uuid can be generated with `Recipe.UUID.generate/0`
 
   ### Example
 
@@ -232,19 +241,21 @@ defmodule Recipe do
   Recipe.run(Workflow, Recipe.empty_state(), log_steps: true)
   ```
   """
-  @spec run(recipe_module, State.t, debug_opts) :: {:ok, term} | {:error, term}
-  def run(recipe_module, initial_state, debug_opts \\ []) do
+  @spec run(recipe_module, State.t, run_opts) :: {:ok, UUID.t, term} | {:error, term}
+  def run(recipe_module, initial_state, run_opts \\ []) do
     steps = recipe_module.steps()
-    final_debug_opts = Keyword.merge(initial_state.debug_opts, debug_opts)
+    final_run_opts = Keyword.merge(initial_state.run_opts, run_opts)
+    correlation_id = Keyword.get(run_opts, :correlation_id, UUID.generate())
 
     state = %{initial_state | recipe_module: recipe_module,
-                              debug_opts: final_debug_opts}
+                              correlation_id: correlation_id,
+                              run_opts: final_run_opts}
 
     do_run(steps, state)
   end
 
   defp do_run([], state) do
-    state.recipe_module.handle_result(state)
+    {:ok, state.correlation_id, state.recipe_module.handle_result(state)}
   end
   defp do_run([step | remaining_steps], state) do
     maybe_log_step(step, state)
@@ -257,9 +268,12 @@ defmodule Recipe do
   end
 
   defp maybe_log_step(step, state) do
-    if Keyword.get(state.debug_opts, :log_steps) do
+    if Keyword.get(state.run_opts, :log_steps) do
       Logger.debug(fn() ->
-        "recipe=#{inspect state.recipe_module} step=#{step} assigns=#{inspect state.assigns}"
+        %{recipe_module: recipe,
+          correlation_id: id,
+          assigns: assigns} = state
+        "recipe=#{inspect recipe} correlation_id=#{id} step=#{step} assigns=#{inspect assigns}"
       end)
     end
   end

--- a/lib/recipe/state.ex
+++ b/lib/recipe/state.ex
@@ -1,13 +1,15 @@
 defmodule Recipe.State do
   @moduledoc false
 
-  @default_debug_opts [log_steps: false]
+  @default_run_opts [log_steps: false]
 
   defstruct assigns: %{},
             recipe_module: NoOp,
-            debug_opts: @default_debug_opts
+            correlation_id: nil,
+            run_opts: @default_run_opts
 
   @type t :: %__MODULE__{assigns: %{},
                          recipe_module: module,
-                         debug_opts: Recipe.debug_opts}
+                         correlation_id: nil | Recipe.UUID.t,
+                         run_opts: Recipe.run_opts}
 end

--- a/lib/recipe/state.ex
+++ b/lib/recipe/state.ex
@@ -1,9 +1,13 @@
 defmodule Recipe.State do
   @moduledoc false
 
+  @default_debug_opts [log_steps: false]
+
   defstruct assigns: %{},
-            recipe_module: NoOp
+            recipe_module: NoOp,
+            debug_opts: @default_debug_opts
 
   @type t :: %__MODULE__{assigns: %{},
-                         recipe_module: module}
+                         recipe_module: module,
+                         debug_opts: Recipe.debug_opts}
 end

--- a/lib/recipe/uuid.ex
+++ b/lib/recipe/uuid.ex
@@ -1,0 +1,53 @@
+defmodule Recipe.UUID do
+  @moduledoc """
+  UUID v4 generator, used for recipe correlation uuid(s).
+
+  Credit goes to: from https://github.com/zyro/elixir-uuid/blob/master/lib/uuid.ex
+  """
+
+  @type t :: String.t
+
+  @spec generate() :: t
+  @doc """
+  Generates a new v4 correlation uuid.
+  """
+  def generate() do
+    <<u0::48, _::4, u1::12, _::2, u2::62>> = :crypto.strong_rand_bytes(16)
+    <<u0::48, 4::4, u1::12, 2::2, u2::62>>
+    |> uuid_to_string()
+  end
+
+  defp uuid_to_string(<<u0::32, u1::16, u2::16, u3::16, u4::48>>) do
+    [binary_to_hex_list(<<u0::32>>), ?-, binary_to_hex_list(<<u1::16>>), ?-,
+     binary_to_hex_list(<<u2::16>>), ?-, binary_to_hex_list(<<u3::16>>), ?-,
+     binary_to_hex_list(<<u4::48>>)]
+     |> IO.iodata_to_binary
+  end
+  defp uuid_to_string(_u) do
+    raise ArgumentError, message:
+    "Invalid binary data; Expected: <<uuid::128>>"
+  end
+
+  defp binary_to_hex_list(binary) do
+    :binary.bin_to_list(binary)
+      |> list_to_hex_str
+  end
+
+  defp list_to_hex_str([]) do
+    []
+  end
+  defp list_to_hex_str([head | tail]) do
+    to_hex_str(head) ++ list_to_hex_str(tail)
+  end
+
+  defp to_hex_str(n) when n < 256 do
+    [to_hex(div(n, 16)), to_hex(rem(n, 16))]
+  end
+
+  defp to_hex(i) when i < 10 do
+    0 + i + 48
+  end
+  defp to_hex(i) when i >= 10 and i < 16 do
+    ?a + (i - 10)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Recipe.Mixfile do
   end
 
   def application do
-    [extra_applications: []]
+    [extra_applications: [:logger]]
   end
 
   defp deps do

--- a/test/recipe_test.exs
+++ b/test/recipe_test.exs
@@ -10,7 +10,7 @@ defmodule RecipeTest do
     def steps, do: [:square, :double]
 
     def handle_result(state) do
-      {:ok, state.assigns.number}
+      state.assigns.number
     end
 
     def handle_error(_step, _error, _state), do: :cannot_fail
@@ -26,28 +26,38 @@ defmodule RecipeTest do
     end
   end
 
-  describe "successful recipe" do
+  describe "recipe run" do
     test "returns the final result" do
       state = Recipe.empty_state
               |> Recipe.assign(:number, 4)
 
-      assert {:ok, 32} == Recipe.run(Successful, state)
+      assert {:ok, _, 32} = Recipe.run(Successful, state)
     end
 
+    test "it reuses a correlation id if passed" do
+      correlation_id = Recipe.UUID.generate()
+      state = Recipe.empty_state
+              |> Recipe.assign(:number, 4)
+
+      assert {:ok, correlation_id, 32} ==
+        Recipe.run(Successful, state, correlation_id: correlation_id)
+    end
   end
 
   describe "debug options" do
-    test "id supports a correlation id" do
+    test "supports logging to debug" do
+      correlation_id = Recipe.UUID.generate()
       expected_log = """
-      recipe=RecipeTest.Successful step=square assigns=%{number: 4}
-      recipe=RecipeTest.Successful step=double assigns=%{number: 16}
+      [debug] recipe=RecipeTest.Successful correlation_id=#{correlation_id} step=square assigns=%{number: 4}
+      [debug] recipe=RecipeTest.Successful correlation_id=#{correlation_id} step=double assigns=%{number: 16}
       """
 
       assert capture_log(fn ->
         state = Recipe.empty_state
                 |> Recipe.assign(:number, 4)
 
-        Recipe.run(Successful, state, log_steps: true)
+        Recipe.run(Successful, state, log_steps: true,
+                                      correlation_id: correlation_id)
       end) == expected_log
     end
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,8 @@
+# Configure logger console backend to output bare messages,
+# no color (makes testing much easier)
+logger_console_opts = [colors: [enabled: false],
+                       format: "$message\n"]
+
+Logger.configure_backend(:console, logger_console_opts)
+
 ExUnit.start()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,7 +1,7 @@
 # Configure logger console backend to output bare messages,
 # no color (makes testing much easier)
 logger_console_opts = [colors: [enabled: false],
-                       format: "$message\n"]
+                       format: "[$level] $message\n"]
 
 Logger.configure_backend(:console, logger_console_opts)
 


### PR DESCRIPTION
This PR includes two new features and one breaking change:

## Correlation id

This can be used to tie together different recipe runs: `Recipe.run/2` will now return `{:ok, correlation_id, result}`, so that the developer can just extract it with pattern matching. To reuse it, the developer can call `Recipe.run(recipe_module, initial_state, correlation_id: correlation_id`

## Log steps

It's also possible to log, at debug level, each step of a recipe. Logging is activated on a per-recipe run basis by passing `log_steps: true` in the options for `Recipe.run/3`.

## Removal of `Recipe.run/1`

It wasn't used.