### PR TITLE
Adds ability to customise log function

### DIFF
--- a/lib/recipe.ex
+++ b/lib/recipe.ex
@@ -144,7 +144,7 @@ defmodule Recipe do
   @type error :: term
   @type run_opts :: [{:log_steps, boolean} | {:correlation_id, UUID.t}]
   @type function_name :: atom
-  @type log_function :: {module, function_name}
+  @type log_function :: {module, function_name} | ((step, t) -> term)
   @type t :: %__MODULE__{assigns: %{},
                          recipe_module: module,
                          correlation_id: nil | Recipe.UUID.t,
@@ -245,10 +245,11 @@ defmodule Recipe do
   Supports an optional third argument (a keyword list) for extra options:
 
   - `:log_steps`: when true, log (at debug level) each step with the updated state
-  - `:log_function`: this value is a 2-element tuple `{module_name, function_name}`;
-    the function will receive two values, the current step name and the current state,
-    and can be used to log the current step execution. By default the `Recipe.log_step/2`
-    function is used. See `t:Recipe.log_function/0` as well to check its typing.
+  - `:log_function`: this value can either be a 2-element tuple `{module_name,
+    function_name}` or a plain function; the function will receive two values,
+    the current step name and the current state, and can be used to log the
+    current step execution. By default the `Recipe.log_step/2` function is used.
+    See `t:Recipe.log_function/0` as well to check its typing.
   - `:correlation_id`: you can override the automatically generated correlation id
     by passing it as an option. A uuid can be generated with `Recipe.UUID.generate/0`
 
@@ -294,16 +295,24 @@ defmodule Recipe do
     {:ok, state.correlation_id, state.recipe_module.handle_result(state)}
   end
   defp do_run([step | remaining_steps], state) do
-    if Keyword.get(state.run_opts, :log_steps) do
-      {module_name, function_name} = state.log_function
-      apply(module_name, function_name, [step, state])
-    end
+    maybe_log_step(step, state)
 
     case apply(state.recipe_module, step, [state]) do
       {:ok, new_state} ->
         do_run(remaining_steps, new_state)
       error ->
         {:error, state.recipe_module.handle_error(step, error, state)}
+    end
+  end
+
+  defp maybe_log_step(step, state) do
+    if Keyword.get(state.run_opts, :log_steps) do
+      case state.log_function do
+        {module_name, function_name} ->
+          apply(module_name, function_name, [step, state])
+        function when is_function(function) ->
+          function.(step, state)
+      end
     end
   end
 end

--- a/test/recipe_test.exs
+++ b/test/recipe_test.exs
@@ -24,6 +24,10 @@ defmodule RecipeTest do
       number = state.assigns.number
       {:ok, Recipe.assign(state, :number, number * 2)}
     end
+
+    def log_step(_step, _state) do
+      send(self(), :log_step_called)
+    end
   end
 
   describe "recipe run" do
@@ -59,6 +63,16 @@ defmodule RecipeTest do
         Recipe.run(Successful, state, log_steps: true,
                                       correlation_id: correlation_id)
       end) == expected_log
+    end
+
+    test "supports a custom log function" do
+      state = Recipe.initial_state
+              |> Recipe.assign(:number, 4)
+
+      Recipe.run(Successful, state, log_steps: true,
+                                    log_function: {Successful, :log_step})
+
+      assert_receive :log_step_called
     end
   end
 end

--- a/test/recipe_test.exs
+++ b/test/recipe_test.exs
@@ -26,7 +26,7 @@ defmodule RecipeTest do
     end
 
     def log_step(_step, _state) do
-      send(self(), :log_step_called)
+      send(self(), :m_f_log)
     end
   end
 
@@ -65,14 +65,27 @@ defmodule RecipeTest do
       end) == expected_log
     end
 
-    test "supports a custom log function" do
+    test "supports a custom log function in {m, f} form" do
       state = Recipe.initial_state
               |> Recipe.assign(:number, 4)
 
       Recipe.run(Successful, state, log_steps: true,
                                     log_function: {Successful, :log_step})
 
-      assert_receive :log_step_called
+      assert_receive :m_f_log
+    end
+
+    test "supports a custom log function in fn form" do
+      state = Recipe.initial_state
+              |> Recipe.assign(:number, 4)
+      log_function = fn(_step, _state) ->
+        send(self(), :fn_called)
+      end
+
+      Recipe.run(Successful, state, log_steps: true,
+                                    log_function: log_function)
+
+      assert_receive :fn_called
     end
   end
 end


### PR DESCRIPTION
When a workflow is run with `log_steps` set to true, steps are logged.

This PR makes the logging function configurable, with a default set to `Recipe.log_step/2`. See the docs for `Recipe.run/2` for more details.

Closes #6 