### PR TITLE
Telemetry support

### DIFF
--- a/lib/recipe.ex
+++ b/lib/recipe.ex
@@ -41,6 +41,7 @@ defmodule Recipe do
     with the result of all previous steps
   - Each step should be easily testable in isolation
   - Each workflow run is identified by a correlation id
+  - Each workflow needs to be easily audited via logs or an event store
 
   ### Example
 
@@ -124,6 +125,42 @@ defmodule Recipe do
         def broadcast_new_message(state) do
           Dispatcher.broadcast("message-created", state.assigns.initial_message)
           {:ok, state}
+        end
+      end
+
+  ### Telemetry
+
+  A recipe run can be instrumented with callbacks for start, end and each step execution.
+
+  To instrument a recipe run, it's sufficient to call:
+
+      Recipe.run(module, initial_state, enable_telemetry: true)
+
+  The default setting for telemetry is to use the `Recipe.Debug` module, but you can implement
+  your own by using the `Recipe.Telemetry` behaviour, definining the needed callbacks and run
+  the recipe as follows:
+
+      Recipe.run(module, initial_state, enable_telemetry: true, telemetry_module: MyModule)
+
+  An example of a compliant module can be:
+
+      defmodule Recipe.Debug do
+        use Recipe.Telemetry
+
+        def on_start(state) do
+          IO.inspect(state)
+        end
+
+        def on_finish(state) do
+          IO.inspect(state)
+        end
+
+        def on_success(step, state, elapsed_microseconds) do
+          IO.inspect([step, state, elapsed_microseconds])
+        end
+
+        def on_error(step, error, state, elapsed_microseconds) do
+          IO.inspect([step, error, state, elapsed_microseconds])
         end
       end
   """

--- a/lib/recipe.ex
+++ b/lib/recipe.ex
@@ -131,24 +131,24 @@ defmodule Recipe do
   alias Recipe.UUID
   require Logger
 
-  @default_run_opts [log_steps: false]
+  @default_run_opts [enable_telemetry: false]
 
   defstruct assigns: %{},
             recipe_module: NoOp,
             correlation_id: nil,
-            log_function: {__MODULE__, :log_step},
+            telemetry_module: Recipe.Debug,
             run_opts: @default_run_opts
 
   @type step :: atom
   @type recipe_module :: atom
   @type error :: term
-  @type run_opts :: [{:log_steps, boolean} | {:correlation_id, UUID.t}]
+  @type run_opts :: [{:enable_telemetry, boolean} | {:correlation_id, UUID.t}]
   @type function_name :: atom
-  @type log_function :: {module, function_name} | ((step, t) -> term)
+  @type telemetry_module :: module
   @type t :: %__MODULE__{assigns: %{},
                          recipe_module: module,
                          correlation_id: nil | Recipe.UUID.t,
-                         log_function: log_function,
+                         telemetry_module: telemetry_module,
                          run_opts: Recipe.run_opts}
 
   @doc """
@@ -244,19 +244,19 @@ defmodule Recipe do
 
   Supports an optional third argument (a keyword list) for extra options:
 
-  - `:log_steps`: when true, log (at debug level) each step with the updated state
-  - `:log_function`: this value can either be a 2-element tuple `{module_name,
-    function_name}` or a plain function; the function will receive two values,
-    the current step name and the current state, and can be used to log the
-    current step execution. By default the `Recipe.log_step/2` function is used.
-    See `t:Recipe.log_function/0` as well to check its typing.
+  - `:enable_telemetry`: when true, uses the configured telemetry module to log
+    and collect metrics around the recipe execution
+  - `:telemetry_module`: the telemetry module to use when logging events and metrics.
+    The module needs to implement the `Recipe.Telemetry` behaviour (see related docs),
+    it's set by default to `Recipe.Debug` and it's only used when `:enable_telemetry`
+    is set to true
   - `:correlation_id`: you can override the automatically generated correlation id
     by passing it as an option. A uuid can be generated with `Recipe.UUID.generate/0`
 
   ### Example
 
   ```
-  Recipe.run(Workflow, Recipe.initial_state(), log_steps: true)
+  Recipe.run(Workflow, Recipe.initial_state(), enable_telemetry: true)
   ```
   """
   @spec run(recipe_module, t, run_opts) :: {:ok, UUID.t, term} | {:error, term}
@@ -264,55 +264,53 @@ defmodule Recipe do
     steps = recipe_module.steps()
     final_run_opts = Keyword.merge(initial_state.run_opts, run_opts)
     correlation_id = Keyword.get(run_opts, :correlation_id, UUID.generate())
-    log_function = Keyword.get(run_opts, :log_function, initial_state.log_function)
+    telemetry_module = Keyword.get(run_opts, :telemetry_module, initial_state.telemetry_module)
 
     state = %{initial_state | recipe_module: recipe_module,
                               correlation_id: correlation_id,
-                              log_function: log_function,
+                              telemetry_module: telemetry_module,
                               run_opts: final_run_opts}
 
+    maybe_on_start(state)
     do_run(steps, state)
   end
 
-  @doc """
-  Logs a step execution (debug level).
-
-  This function is used by default when a recipe is run with `log_steps: true` and
-  can be overridden by passing `log_function: {module, function_name}`. See the documentation
-  for `Recipe.run/3` for more information.
-  """
-  @spec log_step(step, t) :: :ok
-  def log_step(step, state) do
-    Logger.debug(fn() ->
-      %{recipe_module: recipe,
-        correlation_id: id,
-        assigns: assigns} = state
-      "recipe=#{inspect recipe} correlation_id=#{id} step=#{step} assigns=#{inspect assigns}"
-    end)
-  end
-
   defp do_run([], state) do
+    maybe_on_finish(state)
     {:ok, state.correlation_id, state.recipe_module.handle_result(state)}
   end
   defp do_run([step | remaining_steps], state) do
-    maybe_log_step(step, state)
-
-    case apply(state.recipe_module, step, [state]) do
-      {:ok, new_state} ->
+    case :timer.tc(state.recipe_module, step, [state]) do
+      {elapsed, {:ok, new_state}} ->
+        maybe_on_success(step, new_state, elapsed)
         do_run(remaining_steps, new_state)
-      error ->
+      {elapsed, error} ->
+        maybe_on_error(step, error, state, elapsed)
         {:error, state.recipe_module.handle_error(step, error, state)}
     end
   end
 
-  defp maybe_log_step(step, state) do
-    if Keyword.get(state.run_opts, :log_steps) do
-      case state.log_function do
-        {module_name, function_name} ->
-          apply(module_name, function_name, [step, state])
-        function when is_function(function) ->
-          function.(step, state)
-      end
+  defp maybe_on_start(state) do
+    if Keyword.get(state.run_opts, :enable_telemetry) do
+      state.telemetry_module.on_start(state)
+    end
+  end
+
+  defp maybe_on_success(step, state, elapsed) do
+    if Keyword.get(state.run_opts, :enable_telemetry) do
+      state.telemetry_module.on_success(step, state, elapsed)
+    end
+  end
+
+  defp maybe_on_error(step, error, state, elapsed) do
+    if Keyword.get(state.run_opts, :enable_telemetry) do
+      state.telemetry_module.on_error(step, error, state, elapsed)
+    end
+  end
+
+  defp maybe_on_finish(state) do
+    if Keyword.get(state.run_opts, :enable_telemetry) do
+      state.telemetry_module.on_finish(state)
     end
   end
 end

--- a/lib/recipe/debug.ex
+++ b/lib/recipe/debug.ex
@@ -1,0 +1,47 @@
+defmodule Recipe.Debug do
+  @moduledoc """
+  Built-in telemetry module which uses `Logger` to report events related to
+  a recipe run.
+
+  Implements the `Recipe.Telemetry` behaviour.
+  """
+  use Recipe.Telemetry
+
+  require Logger
+
+  def on_start(state) do
+    Logger.debug(fn() ->
+      %{recipe_module: recipe,
+        correlation_id: id,
+        assigns: assigns} = state
+      "recipe=#{inspect recipe} evt=start correlation_id=#{id} assigns=#{inspect assigns}"
+    end)
+  end
+
+  def on_finish(state) do
+    Logger.debug(fn() ->
+      %{recipe_module: recipe,
+        correlation_id: id,
+        assigns: assigns} = state
+      "recipe=#{inspect recipe} evt=end correlation_id=#{id} assigns=#{inspect assigns}"
+    end)
+  end
+
+  def on_success(step, state, elapsed) do
+    Logger.debug(fn() ->
+      %{recipe_module: recipe,
+        correlation_id: id,
+        assigns: assigns} = state
+      "recipe=#{inspect recipe} evt=step correlation_id=#{id} step=#{step} assigns=#{inspect assigns} duration=#{elapsed}"
+    end)
+  end
+
+  def on_error(step, error, state, elapsed) do
+    Logger.error(fn() ->
+      %{recipe_module: recipe,
+        correlation_id: id,
+        assigns: assigns} = state
+      "recipe=#{inspect recipe} evt=error correlation_id=#{id} step=#{step} error=#{inspect error} assigns=#{inspect assigns} duration=#{elapsed}"
+    end)
+  end
+end

--- a/lib/recipe/telemetry.ex
+++ b/lib/recipe/telemetry.ex
@@ -1,0 +1,42 @@
+defmodule Recipe.Telemetry do
+  @moduledoc """
+  The `Recipe.Telemetry` behaviour can be used to define
+  a module capable of handling events emitted by a recipe
+  run.
+
+  Each callback is invoked at different step of a recipe run, receiving
+  data about the current step and its execution time.
+
+  Please refer to the docs for `Recipe.run/3` to see how to
+  enable debug and telemetry information.
+  """
+
+  @type elapsed_microseconds :: integer()
+
+  @doc """
+  Invoked at the start of a recipe execution.
+  """
+  @callback on_start(Recipe.t) :: :ok
+
+  @doc """
+  Invoked at the end of a recipe execution, irrespectively of
+  the success or failure of the last executed step.
+  """
+  @callback on_finish(Recipe.t) :: :ok
+
+  @doc """
+  Invoked after successfully executing a step.
+  """
+  @callback on_success(Recipe.step, Recipe.t, elapsed_microseconds) :: :ok
+
+  @doc """
+  Invoked after failing to execute a step.
+  """
+  @callback on_error(Recipe.step, term, Recipe.t, elapsed_microseconds) :: :ok
+
+  defmacro __using__(_opts) do
+    quote do
+      @behaviour Recipe.Telemetry
+    end
+  end
+end

--- a/test/recipe/debug_test.exs
+++ b/test/recipe/debug_test.exs
@@ -1,0 +1,52 @@
+defmodule Recipe.DebugTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  @correlation_id Recipe.UUID.generate()
+  @state %Recipe{correlation_id: @correlation_id,
+                 recipe_module: Example,
+                 assigns: %{number: 4}}
+
+  test "on_start/1" do
+    expected = """
+    [debug] recipe=Example evt=start correlation_id=#{@correlation_id} assigns=%{number: 4}
+    """
+
+    assert capture_log(fn() ->
+      Recipe.Debug.on_start(@state)
+    end) == expected
+
+    # [debug] recipe=RecipeTest.Successful evt=step correlation_id=#{correlation_id} step=double assigns=%{number: 32}
+  end
+
+  test "on_finish/1" do
+    expected = """
+    [debug] recipe=Example evt=end correlation_id=#{@correlation_id} assigns=%{number: 4}
+    """
+
+    assert capture_log(fn() ->
+      Recipe.Debug.on_finish(@state)
+    end) == expected
+  end
+
+  test "on_success/3" do
+    expected = """
+    [debug] recipe=Example evt=step correlation_id=#{@correlation_id} step=square assigns=%{number: 4} duration=9
+    """
+
+    assert capture_log(fn() ->
+      Recipe.Debug.on_success(:square, @state, 9)
+    end) == expected
+  end
+
+  test "on_error/4" do
+    expected = """
+    [error] recipe=Example evt=error correlation_id=#{@correlation_id} step=square error={:error, :less_than_5} assigns=%{number: 4} duration=2
+    """
+
+    assert capture_log(fn() ->
+      Recipe.Debug.on_error(:square, {:error, :less_than_5}, @state, 2)
+    end) == expected
+  end
+end


### PR DESCRIPTION
Replaces log functionality with telemetry 

- More hooks: start, end, successful step, failed step
- Includes elapsed time for each step

Closes #7 and #10 