### PR TITLE
Improve compile time exception messages

### DIFF
--- a/lib/recipe.ex
+++ b/lib/recipe.ex
@@ -202,7 +202,7 @@ defmodule Recipe do
         enable_telemetry: true
   """
 
-  alias Recipe.UUID
+  alias Recipe.{InvalidRecipe, UUID}
   require Logger
 
   @default_run_opts [enable_telemetry: false]
@@ -240,50 +240,6 @@ defmodule Recipe do
   the error and the state.
   """
   @callback handle_error(step, error, t) :: term
-
-  defmodule InvalidRecipe do
-    @moduledoc """
-    This exception is raised whenever a module that implements the `Recipe`
-    behaviour does not define a function definition for each listed step.
-    """
-    defexception [:message]
-
-    def missing_steps(recipe_module) do
-      """
-
-          #{IO.ANSI.red}
-          The recipe #{inspect recipe_module} doesn't define
-          the steps to execute.
-
-          To fix this, you need to define a steps/0 function.
-
-          For example:
-
-          def steps, do: [:validate, :save]#{IO.ANSI.default_color}
-      """
-    end
-
-    def missing_step_definitions(recipe_module, missing_steps) do
-      [example_step | _rest] = missing_steps
-
-      """
-
-          #{IO.ANSI.red}
-          The recipe #{inspect recipe_module} doesn't have step definitions
-          for the following functions:
-
-          #{inspect missing_steps}
-
-          To fix this, you need to add the relevant
-          function definitions. For example:
-
-          def #{example_step}(state) do
-            # your code here
-            {:ok, new_state}
-          end#{IO.ANSI.default_color}
-      """
-    end
-  end
 
   defmacro __using__(_opts) do
     quote do

--- a/lib/recipe/invalid_recipe.ex
+++ b/lib/recipe/invalid_recipe.ex
@@ -1,0 +1,43 @@
+defmodule Recipe.InvalidRecipe do
+  @moduledoc """
+  This exception is raised whenever a module that implements the `Recipe`
+  behaviour does not define a function definition for each listed step.
+  """
+  defexception [:message]
+
+  def missing_steps(recipe_module) do
+    """
+
+        #{IO.ANSI.red}
+        The recipe #{inspect recipe_module} doesn't define
+        the steps to execute.
+
+        To fix this, you need to define a steps/0 function.
+
+        For example:
+
+        def steps, do: [:validate, :save]#{IO.ANSI.default_color}
+    """
+  end
+
+  def missing_step_definitions(recipe_module, missing_steps) do
+    [example_step | _rest] = missing_steps
+
+    """
+
+        #{IO.ANSI.red}
+        The recipe #{inspect recipe_module} doesn't have step definitions
+        for the following functions:
+
+        #{inspect missing_steps}
+
+        To fix this, you need to add the relevant
+        function definitions. For example:
+
+        def #{example_step}(state) do
+          # your code here
+          {:ok, new_state}
+        end#{IO.ANSI.default_color}
+    """
+  end
+end


### PR DESCRIPTION
This PR improves the compile-time exception messages by making them more descriptive and by offering suggestions on what to do next.

### Examples

When a recipe module doesn't define a `steps/0` definition:

```
== Compilation error on file lib/sample.ex ==
** (Recipe.InvalidRecipe)

    The recipe Sample doesn't define
    the steps to execute.

    To fix this, you need to define a steps/0 function.

    For example:

    def steps, do: [:validate, :save]

    lib/sample.ex:2: Sample.__after_compile__/2
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
```

When a recipe module doesn't define all step definitions:

```
== Compilation error on file lib/sample.ex ==
** (Recipe.InvalidRecipe)

    The recipe Sample doesn't have step definitions
    for the following functions:

    [:foo]

    To fix this, you need to add the relevant
    function definitions. For example:

    def foo(state) do
      # your code here
      {:ok, new_state}
    end

    lib/sample.ex:2: Sample.__after_compile__/2
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
```